### PR TITLE
Ensure single-run batch output retains asset links

### DIFF
--- a/src/core/markdown_converter/core.py
+++ b/src/core/markdown_converter/core.py
@@ -114,6 +114,10 @@ class ConversionService:
         from .utils import atomic_write
 
         atomic_write(run_paths.output_file, markdown)
+        # propagate any markdown mutations (e.g., appended asset links) to the
+        # response object so callers aggregating the response body do not lose
+        # the references written to disk.
+        response.markdown = markdown
         write_elapsed = (time.perf_counter() - write_start) * 1000
 
         logger.append(


### PR DESCRIPTION
## Summary
- update `_convert_internal` to write asset references back onto the adapter response
- keep single-run batch aggregation in sync with on-disk markdown

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e71b666230832ab1275a0f762d73bb